### PR TITLE
Once upon a time, there was a trouble for url building to github.

### DIFF
--- a/doc_en/var/config/profiles.ini.php.dist
+++ b/doc_en/var/config/profiles.ini.php.dist
@@ -141,46 +141,46 @@ path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.0
 title="Manual Jelix 1.0"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 
 [gtwrepo:manual-1.1]
 path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.1
 title="Manual Jelix 1.1"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 
 [gtwrepo:manual-1.2]
 path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.2
 title="Manual Jelix 1.2"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 
 [gtwrepo:manual-1.3]
 path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.3
 title="Manual Jelix 1.3"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 
 [gtwrepo:manual-1.4]
 path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.4
 title="Manual Jelix 1.4"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 
 [gtwrepo:manual-1.5]
 path="app:../repositories/en/jelix-manual-en/.git"
 generators=gitiwikiGenerators
 branch=master
 title="Manual Jelix 1.5"
-gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manual-en/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manual-en/blob/%branch%/%file%"
 

--- a/doc_fr/var/config/profiles.ini.php.dist
+++ b/doc_fr/var/config/profiles.ini.php.dist
@@ -142,46 +142,46 @@ path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.0
 title="Manuel Jelix 1.0"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 
 [gtwrepo:manuel-1.1]
 path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.1
 title="Manuel Jelix 1.1"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 
 [gtwrepo:manuel-1.2]
 path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.2
 title="Manuel Jelix 1.2"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 
 [gtwrepo:manuel-1.3]
 path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.3
 title="Manuel Jelix 1.3"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 
 [gtwrepo:manuel-1.4]
 path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=jelix-1.4
 title="Manuel Jelix 1.4"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 
 [gtwrepo:manuel-1.5]
 path="app:../repositories/fr/jelix-manuel-fr/.git"
 generators=gitiwikiGenerators
 branch=master
 title="Manuel Jelix 1.5"
-gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%%file%"
-gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%%file%"
+gitSourceEditURL="https://github.com/jelix/jelix-manuel-fr/edit/%branch%/%file%"
+gitSourceViewURL="https://github.com/jelix/jelix-manuel-fr/blob/%branch%/%file%"
 

--- a/modules/gitiwiki/classes/gtwFile.class.php
+++ b/modules/gitiwiki/classes/gtwFile.class.php
@@ -54,7 +54,11 @@ class gtwFile extends gtwFileBase {
     }
 
     function getPathFileName() {
-        return $this->path.'/'.$this->name;
+        if( $this->path == '' ) {
+            return $this->name;
+        } else {
+            return $this->path.'/'.$this->name;
+        }
     }
 
     function exists() {


### PR DESCRIPTION
Laurenj fixed it on the server but it seems it has never been commited. Here is a fix (I **think** it is cleaner than on the server because it avoid double slashes). Tested only on the www part ...
